### PR TITLE
Use benchmarkdotnet-results-publisher

### DIFF
--- a/adventofcode/data.json
+++ b/adventofcode/data.json
@@ -1,5 +1,5 @@
-window.BENCHMARK_DATA = {
-  "lastUpdate": 1723789519342,
+{
+  "lastUpdated": 1723789519342,
   "repoUrl": "https://github.com/martincostello/adventofcode",
   "entries": {
     "Advent of Code": [
@@ -16,7 +16,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "c0a3f5eb26b9b1a1428dcc278aab8d1cb5fa03bf",
+          "sha": "c0a3f5eb26b9b1a1428dcc278aab8d1cb5fa03bf",
           "message": "Only run 2016 benchmarks\n\nOnly run the benchmarks for 2016 to limit the duration.",
           "timestamp": "2024-08-11T13:07:06+01:00",
           "tree_id": "dbb02a131879a0cc8ff0c3ca9cade8ba6d1363ea",
@@ -136,7 +136,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "38aee836b60f4f0fd7265de06a1e402cc2311ded",
+          "sha": "38aee836b60f4f0fd7265de06a1e402cc2311ded",
           "message": "Add continuous benchmarks (#1818)\n\nAdd GitHub Actions workflow to run continuous benchmarks and publish to a tracking website.",
           "timestamp": "2024-08-11T12:23:48Z",
           "tree_id": "61d3341a5c667543a8f4fca7427d6ac2810cdff7",
@@ -256,7 +256,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "ea5488b53f2f7aa3de9e722d392c700d74564683",
+          "sha": "ea5488b53f2f7aa3de9e722d392c700d74564683",
           "message": "Bump eslint from 9.8.0 to 9.9.0 in /src/AdventOfCode.Site (#1819)\n\nBumps [eslint](https://github.com/eslint/eslint) from 9.8.0 to 9.9.0.\n- [Release notes](https://github.com/eslint/eslint/releases)\n- [Changelog](https://github.com/eslint/eslint/blob/main/CHANGELOG.md)\n- [Commits](https://github.com/eslint/eslint/compare/v9.8.0...v9.9.0)\n\n---\nupdated-dependencies:\n- dependency-name: eslint\n  dependency-type: direct:development\n  update-type: version-update:semver-minor\n...\n\nSigned-off-by: dependabot[bot] <support@github.com>\nCo-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>",
           "timestamp": "2024-08-11T19:32:41Z",
           "tree_id": "74bcefa0d6856d4cc312eb17c60af1f2b848ce35",
@@ -376,7 +376,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "ad98756a4bab8a4de5ddb546f9baf554ffcbb802",
+          "sha": "ad98756a4bab8a4de5ddb546f9baf554ffcbb802",
           "message": "Benchmark .NET vNext (#1820)\n\n- Run benchmarks for pushes to the vNext branches.\r\n- Remove concurrency.",
           "timestamp": "2024-08-12T11:46:10Z",
           "tree_id": "9e8cd0cf1896b781ce5848cc424551d60ef3c226",
@@ -496,7 +496,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "015e5e6ffc2a51110216016ad34f118d074a6bd0",
+          "sha": "015e5e6ffc2a51110216016ad34f118d074a6bd0",
           "message": "Bump the typescript-eslint group (#1821)\n\nBumps the typescript-eslint group in /src/AdventOfCode.Site with 2 updates: [@typescript-eslint/eslint-plugin](https://github.com/typescript-eslint/typescript-eslint/tree/HEAD/packages/eslint-plugin) and [@typescript-eslint/parser](https://github.com/typescript-eslint/typescript-eslint/tree/HEAD/packages/parser).\n\n\nUpdates `@typescript-eslint/eslint-plugin` from 8.0.1 to 8.1.0\n- [Release notes](https://github.com/typescript-eslint/typescript-eslint/releases)\n- [Changelog](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/CHANGELOG.md)\n- [Commits](https://github.com/typescript-eslint/typescript-eslint/commits/v8.1.0/packages/eslint-plugin)\n\nUpdates `@typescript-eslint/parser` from 8.0.1 to 8.1.0\n- [Release notes](https://github.com/typescript-eslint/typescript-eslint/releases)\n- [Changelog](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/parser/CHANGELOG.md)\n- [Commits](https://github.com/typescript-eslint/typescript-eslint/commits/v8.1.0/packages/parser)\n\n---\nupdated-dependencies:\n- dependency-name: \"@typescript-eslint/eslint-plugin\"\n  dependency-type: direct:development\n  update-type: version-update:semver-minor\n  dependency-group: typescript-eslint\n- dependency-name: \"@typescript-eslint/parser\"\n  dependency-type: direct:development\n  update-type: version-update:semver-minor\n  dependency-group: typescript-eslint\n...\n\nSigned-off-by: dependabot[bot] <support@github.com>\nCo-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>",
           "timestamp": "2024-08-13T04:14:26Z",
           "tree_id": "bbf4dbb25da89908918aea91df447489c73c1502",
@@ -616,7 +616,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "cef15f71bc5e33d1417d333800a7e08749283859",
+          "sha": "cef15f71bc5e33d1417d333800a7e08749283859",
           "message": "Bump Microsoft.Playwright from 1.45.1 to 1.46.0 (#1822)\n\nBumps [Microsoft.Playwright](https://github.com/microsoft/playwright-dotnet) from 1.45.1 to 1.46.0.\n- [Release notes](https://github.com/microsoft/playwright-dotnet/releases)\n- [Commits](https://github.com/microsoft/playwright-dotnet/compare/v1.45.1...v1.46.0)\n\n---\nupdated-dependencies:\n- dependency-name: Microsoft.Playwright\n  dependency-type: direct:production\n  update-type: version-update:semver-minor\n...\n\nSigned-off-by: dependabot[bot] <support@github.com>\nCo-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>",
           "timestamp": "2024-08-13T04:34:18Z",
           "tree_id": "c9385d43325fb73f5a5f13925f6868c49b897f73",
@@ -736,7 +736,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "fa7793e2b3e0c56d74740743471072d8c09d1fe4",
+          "sha": "fa7793e2b3e0c56d74740743471072d8c09d1fe4",
           "message": "Update .NET SDK to 8.0.400 (#1824)\n\n* Update .NET SDK\n\nUpdate .NET SDK to version 8.0.400.\n\n---\nupdated-dependencies:\n- dependency-name: Microsoft.NET.Sdk\n  dependency-type: direct:production\n  update-type: version-update:semver-patch\n...\n\nSigned-off-by: costellobot <102549341+costellobot@users.noreply.github.com>\n\n* Bump Microsoft.AspNetCore.Mvc.Testing from 8.0.7 to 8.0.8\n\nBumps Microsoft.AspNetCore.Mvc.Testing from 8.0.7 to 8.0.8.\n\n---\nupdated-dependencies:\n- dependency-name: Microsoft.AspNetCore.Mvc.Testing\n  dependency-type: direct:production\n  update-type: version-update:semver-patch\n...\n\nSigned-off-by: costellobot <102549341+costellobot@users.noreply.github.com>\n\n---------\n\nSigned-off-by: costellobot <102549341+costellobot@users.noreply.github.com>",
           "timestamp": "2024-08-13T17:00:04Z",
           "tree_id": "833fa98ecebde433425ee5252420ccf04051a474",
@@ -856,7 +856,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "4c07aa415e83d9f75c1f6b55eab59df7e4fdf9ca",
+          "sha": "4c07aa415e83d9f75c1f6b55eab59df7e4fdf9ca",
           "message": "Bump elliptic\n\nBump elliptic to 6.5.7 to resolve vulnerability alert.",
           "timestamp": "2024-08-14T13:26:16+01:00",
           "tree_id": "e968ceb53a5364d67f1debef432b15dc3d58d8fa",
@@ -976,7 +976,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "e99974dd63d3882446ce3ede4cdb270b3637e79b",
+          "sha": "e99974dd63d3882446ce3ede4cdb270b3637e79b",
           "message": "Remove BenchmarkDotNet.TestAdapter\r\nRemove BenchmarkDotNet.TestAdapter as it's not being used anyway.",
           "timestamp": "2024-08-15T16:31:21+01:00",
           "tree_id": "8c0c065bd201a74a05c5dc0ef3673a56d1df06f7",
@@ -1096,7 +1096,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "c3d5a30a9e0c692eccc1c3906946d145531102a8",
+          "sha": "c3d5a30a9e0c692eccc1c3906946d145531102a8",
           "message": "Update .NET SDK (#1832)\n\nUpdate .NET SDK to version 8.0.401.\n\n---\nupdated-dependencies:\n- dependency-name: Microsoft.NET.Sdk\n  dependency-type: direct:production\n  update-type: version-update:semver-patch\n...\n\nSigned-off-by: costellobot <102549341+costellobot@users.noreply.github.com>",
           "timestamp": "2024-08-15T17:40:58Z",
           "tree_id": "a02968fecff8bb86be29eab6c7efb063249da450",
@@ -1216,7 +1216,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "1da02e8ff62511f40dcf8e70a38ccc481fa98ff3",
+          "sha": "1da02e8ff62511f40dcf8e70a38ccc481fa98ff3",
           "message": "Bump @stylistic/eslint-plugin in /src/AdventOfCode.Site (#1833)",
           "timestamp": "2024-08-16T07:21:48+01:00",
           "tree_id": "5b0f51ed9e79f2b26cd55af36a37bb09d7b3c501",

--- a/adventofcode/index.html
+++ b/adventofcode/index.html
@@ -130,7 +130,7 @@
     <footer>
       <p>
         &copy; Martin Costello 2024 |
-        Powered by <a rel="noopener" href="https://github.com/benchmark-action/github-action-benchmark">github-action-benchmark</a>
+        Powered by <a rel="noopener" href="https://github.com/martincostello/benchmarkdotnet-results-publisher">benchmarkdotnet-results-publisher</a>
         <button class="btn btn-primary btn-sm d-none d-md-block float-end" id="download-json" type="button">
           Download as JSON
           <span class="fa-solid fa-file-arrow-down" aria-hidden="true"></span>

--- a/api/data.json
+++ b/api/data.json
@@ -1,5 +1,5 @@
-window.BENCHMARK_DATA = {
-  "lastUpdate": 1723789705525,
+{
+  "lastUpdated": 1723789705525,
   "repoUrl": "https://github.com/martincostello/api",
   "entries": {
     "API": [
@@ -16,7 +16,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "25a0476e55faa1cd75c95e3eff9820c94f98bf2c",
+          "sha": "25a0476e55faa1cd75c95e3eff9820c94f98bf2c",
           "message": "Add continuous benchmarks\n\nAdd GitHub Actions workflow to run continuous benchmarks and publish to a tracking website.",
           "timestamp": "2024-08-09T15:42:07+01:00",
           "tree_id": "23a8c1cd65bce3a52088218f8377ce1e0dd910b7",
@@ -52,7 +52,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "c5d63b8c785df53563ead5ab52ebe6a27f44287e",
+          "sha": "c5d63b8c785df53563ead5ab52ebe6a27f44287e",
           "message": "Move benchmarks\n\nPublish to subdirectory.",
           "timestamp": "2024-08-09T16:14:06+01:00",
           "tree_id": "10053e6777153185080090ae07c6a27dd8546233",
@@ -88,7 +88,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "b2489d48f440c507ec6b281e96225a192ed01b32",
+          "sha": "b2489d48f440c507ec6b281e96225a192ed01b32",
           "message": "Add continuous benchmarks (#1903)\n\nAdd GitHub Actions workflow to run continuous benchmarks and publish to a tracking website.",
           "timestamp": "2024-08-09T15:43:49Z",
           "tree_id": "eafe925b1c3304725d323f83cc8e7d07deed3de5",
@@ -124,7 +124,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "a98681d2511a212a6f476f5991168ce04a4d9460",
+          "sha": "a98681d2511a212a6f476f5991168ce04a4d9460",
           "message": "Add notice for results\n\nAdd a step summary with a link to the results.",
           "timestamp": "2024-08-09T17:23:50+01:00",
           "tree_id": "6b1b9d423837a6d08dac7021bf283237205660fd",
@@ -160,7 +160,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "d38311d65de8e5c1e6e1dcf7bd6407786bf41225",
+          "sha": "d38311d65de8e5c1e6e1dcf7bd6407786bf41225",
           "message": "Bump eslint from 9.8.0 to 9.9.0 in /src/API (#1905)\n\nBumps [eslint](https://github.com/eslint/eslint) from 9.8.0 to 9.9.0.\n- [Release notes](https://github.com/eslint/eslint/releases)\n- [Changelog](https://github.com/eslint/eslint/blob/main/CHANGELOG.md)\n- [Commits](https://github.com/eslint/eslint/compare/v9.8.0...v9.9.0)\n\n---\nupdated-dependencies:\n- dependency-name: eslint\n  dependency-type: direct:development\n  update-type: version-update:semver-minor\n...\n\nSigned-off-by: dependabot[bot] <support@github.com>\nCo-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>",
           "timestamp": "2024-08-10T09:51:13Z",
           "tree_id": "da716ed45aefb76a01c48c1b4d12d090b47a4b93",
@@ -196,7 +196,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "406748cebcf353b47ceef28ca5525de5cdff6303",
+          "sha": "406748cebcf353b47ceef28ca5525de5cdff6303",
           "message": "Rename secret\n\nRename secret for benchmarks.",
           "timestamp": "2024-08-10T17:44:53+01:00",
           "tree_id": "7cceac3a76c71e70c84bb2961c0d83aec3d661aa",
@@ -232,7 +232,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "e61b3fb956910c74e8397b3bc144539d534d3f1b",
+          "sha": "e61b3fb956910c74e8397b3bc144539d534d3f1b",
           "message": "Bump Verify.Xunit from 26.1.6 to 26.2.0 in the xunit group (#1907)\n\nBumps the xunit group with 1 update: [Verify.Xunit](https://github.com/VerifyTests/Verify).\r\n\r\n\r\nUpdates `Verify.Xunit` from 26.1.6 to 26.2.0\r\n- [Release notes](https://github.com/VerifyTests/Verify/releases)\r\n- [Commits](https://github.com/VerifyTests/Verify/compare/26.1.6...26.2.0)\r\n\r\n---\r\nupdated-dependencies:\r\n- dependency-name: Verify.Xunit\r\n  dependency-type: direct:production\r\n  update-type: version-update:semver-minor\r\n  dependency-group: xunit\r\n...\r\n\r\nSigned-off-by: dependabot[bot] <support@github.com>\r\nCo-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>",
           "timestamp": "2024-08-11T11:04:51Z",
           "tree_id": "2986fb46c857371297736bbab9046bd103217ec3",
@@ -268,7 +268,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "470958ebff863d0993f1b616253a0e34a5d36610",
+          "sha": "470958ebff863d0993f1b616253a0e34a5d36610",
           "message": "Move benchmark artifacts\n\nOutput the artifacts to the root of the repository.",
           "timestamp": "2024-08-11T12:19:37+01:00",
           "tree_id": "5f5343e6a54927c7367e449122aafa730a20d17f",
@@ -304,7 +304,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "6e6c9e290057455458061a97a9686f87fff10f18",
+          "sha": "6e6c9e290057455458061a97a9686f87fff10f18",
           "message": "Simplify benchmarks name\n\nRemove \"Benchmarks\" suffix.",
           "timestamp": "2024-08-11T12:31:58+01:00",
           "tree_id": "d7471869d52b7a8bd7a4d4ea87577e209d6ca434",
@@ -340,7 +340,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "66e869d5b72fa27cc95208a7b79bf068338beb1a",
+          "sha": "66e869d5b72fa27cc95208a7b79bf068338beb1a",
           "message": "Add more benchmarks\n\n- Add benchmarks for rendering the homepage and the version.\n- Refactor benchmarks to move server to its own class.",
           "timestamp": "2024-08-11T19:14:24+01:00",
           "tree_id": "bdf14fd0da92d7c08fca3f28bf2d145a81066a9e",
@@ -388,7 +388,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "a92f9950ab6370aed0215d96646fbee957111dd8",
+          "sha": "a92f9950ab6370aed0215d96646fbee957111dd8",
           "message": "Remove web SDK from benchmarks\n\nRemove the web SDK from the benchmarks project so that the artifact directory is not overridden.",
           "timestamp": "2024-08-12T08:24:56+01:00",
           "tree_id": "f91da018c17efb9178bc0af55cca66ffdae8b9b2",
@@ -436,7 +436,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "121bc0eb4c0ac4e8224204bad0706457c701d04d",
+          "sha": "121bc0eb4c0ac4e8224204bad0706457c701d04d",
           "message": "Remove redundant files (#1912)\n\n- Remove files that are now served from CDN.\r\n- Update favicon.ico.",
           "timestamp": "2024-08-12T07:32:16Z",
           "tree_id": "54c6102e623096f6c39ff69710965a170c1fac85",
@@ -484,7 +484,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "ef82f4447d111a87548f1a1314377d921e1c31c0",
+          "sha": "ef82f4447d111a87548f1a1314377d921e1c31c0",
           "message": "Benchmark .NET vNext\n\n- Run benchmarks for pushes to the vNext branches.\n- Remove concurrency.",
           "timestamp": "2024-08-12T11:41:38+01:00",
           "tree_id": "7e8c3bd5855db23d3854d9c075976f9d1c4acf3d",
@@ -532,7 +532,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "92d73ba11875cb13b2ed715512310be7e83e93d3",
+          "sha": "92d73ba11875cb13b2ed715512310be7e83e93d3",
           "message": "Link to branch\n\nLink to the specific branch in the workflow summary.",
           "timestamp": "2024-08-12T12:47:06+01:00",
           "tree_id": "08198407174ba0e026c85ecb1a0e52f218645fa0",
@@ -580,7 +580,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "886ad74e6cd00c5a77ee91b90dad1fe5a49a4206",
+          "sha": "886ad74e6cd00c5a77ee91b90dad1fe5a49a4206",
           "message": "Bump the typescript-eslint group in /src/API with 2 updates (#1915)\n\nBumps the typescript-eslint group in /src/API with 2 updates: [@typescript-eslint/eslint-plugin](https://github.com/typescript-eslint/typescript-eslint/tree/HEAD/packages/eslint-plugin) and [@typescript-eslint/parser](https://github.com/typescript-eslint/typescript-eslint/tree/HEAD/packages/parser).\n\n\nUpdates `@typescript-eslint/eslint-plugin` from 8.0.1 to 8.1.0\n- [Release notes](https://github.com/typescript-eslint/typescript-eslint/releases)\n- [Changelog](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/CHANGELOG.md)\n- [Commits](https://github.com/typescript-eslint/typescript-eslint/commits/v8.1.0/packages/eslint-plugin)\n\nUpdates `@typescript-eslint/parser` from 8.0.1 to 8.1.0\n- [Release notes](https://github.com/typescript-eslint/typescript-eslint/releases)\n- [Changelog](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/parser/CHANGELOG.md)\n- [Commits](https://github.com/typescript-eslint/typescript-eslint/commits/v8.1.0/packages/parser)\n\n---\nupdated-dependencies:\n- dependency-name: \"@typescript-eslint/eslint-plugin\"\n  dependency-type: direct:development\n  update-type: version-update:semver-minor\n  dependency-group: typescript-eslint\n- dependency-name: \"@typescript-eslint/parser\"\n  dependency-type: direct:development\n  update-type: version-update:semver-minor\n  dependency-group: typescript-eslint\n...\n\nSigned-off-by: dependabot[bot] <support@github.com>\nCo-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>",
           "timestamp": "2024-08-13T04:25:58Z",
           "tree_id": "21e772aea0e1ff629d4b6edddc86e80ff750458a",
@@ -628,7 +628,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "122c0da805e35309d86b284ccc2641f2cf197019",
+          "sha": "122c0da805e35309d86b284ccc2641f2cf197019",
           "message": "Update .NET SDK to 8.0.400 (#1917)\n\n* Update .NET SDK\n\nUpdate .NET SDK to version 8.0.400.\n\n---\nupdated-dependencies:\n- dependency-name: Microsoft.NET.Sdk\n  dependency-type: direct:production\n  update-type: version-update:semver-patch\n...\n\nSigned-off-by: costellobot <102549341+costellobot@users.noreply.github.com>\n\n* Bump .NET NuGet packages\n\nBumps .NET dependencies to their latest versions for the .NET 8.0.400 SDK.\n\nBumps Microsoft.AspNetCore.AzureAppServices.HostingStartup from 8.0.7 to 8.0.8.\nBumps Microsoft.AspNetCore.Mvc.Testing from 8.0.7 to 8.0.8.\nBumps Microsoft.Extensions.ApiDescription.Server from 8.0.7 to 8.0.8.\n\n---\nupdated-dependencies:\n- dependency-name: Microsoft.AspNetCore.AzureAppServices.HostingStartup\n  dependency-type: direct:production\n  update-type: version-update:semver-patch\n- dependency-name: Microsoft.AspNetCore.Mvc.Testing\n  dependency-type: direct:production\n  update-type: version-update:semver-patch\n- dependency-name: Microsoft.Extensions.ApiDescription.Server\n  dependency-type: direct:production\n  update-type: version-update:semver-patch\n...\n\nSigned-off-by: costellobot <102549341+costellobot@users.noreply.github.com>\n\n---------\n\nSigned-off-by: costellobot <102549341+costellobot@users.noreply.github.com>",
           "timestamp": "2024-08-13T16:57:51Z",
           "tree_id": "296fcf7e62b26b4dd607f87c102348dcfe437eee",
@@ -676,7 +676,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "5fa1bdec710700bb4920b2392f031d4ddb9edc9a",
+          "sha": "5fa1bdec710700bb4920b2392f031d4ddb9edc9a",
           "message": "Bump Microsoft.Extensions.TimeProvider.Testing from 8.7.0 to 8.8.0 (#1919)\n\nBumps [Microsoft.Extensions.TimeProvider.Testing](https://github.com/dotnet/extensions) from 8.7.0 to 8.8.0.\n- [Release notes](https://github.com/dotnet/extensions/releases)\n- [Commits](https://github.com/dotnet/extensions/commits)\n\n---\nupdated-dependencies:\n- dependency-name: Microsoft.Extensions.TimeProvider.Testing\n  dependency-type: direct:production\n  update-type: version-update:semver-minor\n...\n\nSigned-off-by: dependabot[bot] <support@github.com>\nCo-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>",
           "timestamp": "2024-08-14T04:20:33Z",
           "tree_id": "ad89992d1f87e8bd35bfc64974a31096261b66af",
@@ -724,7 +724,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "a39d4e97449008c61343908a64059e515e7ee985",
+          "sha": "a39d4e97449008c61343908a64059e515e7ee985",
           "message": "Bump elliptic\n\nBump elliptic to 6.5.7 to resolve vulnerability alert.",
           "timestamp": "2024-08-14T12:27:14+01:00",
           "tree_id": "6aa700c6ceb5b408e62b6c8ee501c8e4ac8329c7",
@@ -772,7 +772,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "e971cba547554bcf5e3ff4d39c34fa254b00ec0b",
+          "sha": "e971cba547554bcf5e3ff4d39c34fa254b00ec0b",
           "message": "Remove BenchmarkDotNet.TestAdapter\r\nRemove BenchmarkDotNet.TestAdapter as it's not being used anyway.",
           "timestamp": "2024-08-15T16:25:19+01:00",
           "tree_id": "aa22ae81d89882a615f88ab04e97cd413cfb8ac3",
@@ -820,7 +820,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "fd8e24d69b57c616695b4c6d0601a256bbacd125",
+          "sha": "fd8e24d69b57c616695b4c6d0601a256bbacd125",
           "message": "Bump stylelint from 16.8.1 to 16.8.2 in /src/API (#1926)\n\nBumps [stylelint](https://github.com/stylelint/stylelint) from 16.8.1 to 16.8.2.\r\n- [Release notes](https://github.com/stylelint/stylelint/releases)\r\n- [Changelog](https://github.com/stylelint/stylelint/blob/main/CHANGELOG.md)\r\n- [Commits](https://github.com/stylelint/stylelint/compare/16.8.1...16.8.2)\r\n\r\n---\r\nupdated-dependencies:\r\n- dependency-name: stylelint\r\n  dependency-type: direct:development\r\n  update-type: version-update:semver-patch\r\n...\r\n\r\nSigned-off-by: dependabot[bot] <support@github.com>\r\nCo-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>",
           "timestamp": "2024-08-15T15:29:42Z",
           "tree_id": "146eb2236c19dc6e4f22561066e96ab94aa010e2",
@@ -868,7 +868,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "13b799278e8357207dd3d762d1bb8d26bb2a20a3",
+          "sha": "13b799278e8357207dd3d762d1bb8d26bb2a20a3",
           "message": "Update .NET SDK (#1927)\n\nUpdate .NET SDK to version 8.0.401.\n\n---\nupdated-dependencies:\n- dependency-name: Microsoft.NET.Sdk\n  dependency-type: direct:production\n  update-type: version-update:semver-patch\n...\n\nSigned-off-by: costellobot <102549341+costellobot@users.noreply.github.com>",
           "timestamp": "2024-08-15T17:36:59Z",
           "tree_id": "c70a68f3cc8a6600c91ca2d841b20a4fc470b52a",
@@ -916,7 +916,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "c6c5dc0edc813940d49e5c3746e45b340433b780",
+          "sha": "c6c5dc0edc813940d49e5c3746e45b340433b780",
           "message": "Bump @stylistic/eslint-plugin from 2.6.2 to 2.6.4 in /src/API (#1928)",
           "timestamp": "2024-08-16T07:23:50+01:00",
           "tree_id": "c1020a8dd22cb4b803eb885236feac010e66f57c",

--- a/api/index.html
+++ b/api/index.html
@@ -130,7 +130,7 @@
     <footer>
       <p>
         &copy; Martin Costello 2024 |
-        Powered by <a rel="noopener" href="https://github.com/benchmark-action/github-action-benchmark">github-action-benchmark</a>
+        Powered by <a rel="noopener" href="https://github.com/martincostello/benchmarkdotnet-results-publisher">benchmarkdotnet-results-publisher</a>
         <button class="btn btn-primary btn-sm d-none d-md-block float-end" id="download-json" type="button">
           Download as JSON
           <span class="fa-solid fa-file-arrow-down" aria-hidden="true"></span>

--- a/aspnetcore-openapi/data.json
+++ b/aspnetcore-openapi/data.json
@@ -1,5 +1,5 @@
-window.BENCHMARK_DATA = {
-  "lastUpdate": 1723789543148,
+{
+  "lastUpdated": 1723789543148,
   "repoUrl": "https://github.com/martincostello/aspnetcore-openapi",
   "entries": {
     "ASP.NET Core OpenAPI": [
@@ -16,7 +16,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "fd5d79a12deeeda3abc10b61a80f2568bd38b381",
+          "sha": "fd5d79a12deeeda3abc10b61a80f2568bd38b381",
           "message": "Add continuous benchmarks\n\nAdd GitHub Actions workflow to run continuous benchmarks and publish to a tracking website.",
           "timestamp": "2024-08-12T13:39:14+01:00",
           "tree_id": "cddf6280d24cf54fafcdf274cdaac40f25e0cb94",
@@ -58,7 +58,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "57eae15e2f13af00a9af9e670eea047016def2da",
+          "sha": "57eae15e2f13af00a9af9e670eea047016def2da",
           "message": "Bump dependencies\n\nUpdate Microsoft.Playwright and Verify.Xunit to their latest versions.",
           "timestamp": "2024-08-13T10:36:12+01:00",
           "tree_id": "481540913706dc4944204797fda2d3e02937c1d3",
@@ -100,7 +100,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "2e9e0fcbb40c115838d0326b2574c3c2a1024c2b",
+          "sha": "2e9e0fcbb40c115838d0326b2574c3c2a1024c2b",
           "message": "Use official NuGet packages\n\n- Use official NuGet packages for .NET 9 preview 7.\n- Update .NET SDK.",
           "timestamp": "2024-08-13T15:00:50+01:00",
           "tree_id": "f6b78e91970b7fe36350355ae9003e00e1d9d45e",
@@ -142,7 +142,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "f2eb177fdbb48b0d6a776d0576ed0625309736a8",
+          "sha": "f2eb177fdbb48b0d6a776d0576ed0625309736a8",
           "message": "Remove workaround\n\nRemove workaround for install issue with .NET 9.",
           "timestamp": "2024-08-13T16:25:52+01:00",
           "tree_id": "ec0d4947931af3b0e6e7cb4cc16e834e009ae08d",
@@ -184,7 +184,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "f3c8b171cf37a60aece50c056baea75ba3416ec4",
+          "sha": "f3c8b171cf37a60aece50c056baea75ba3416ec4",
           "message": "Bump the typescript-eslint group in /src/TodoApp with 2 updates (#42)\n\nBumps the typescript-eslint group in /src/TodoApp with 2 updates: [@typescript-eslint/eslint-plugin](https://github.com/typescript-eslint/typescript-eslint/tree/HEAD/packages/eslint-plugin) and [@typescript-eslint/parser](https://github.com/typescript-eslint/typescript-eslint/tree/HEAD/packages/parser).\n\n\nUpdates `@typescript-eslint/eslint-plugin` from 8.0.1 to 8.1.0\n- [Release notes](https://github.com/typescript-eslint/typescript-eslint/releases)\n- [Changelog](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/CHANGELOG.md)\n- [Commits](https://github.com/typescript-eslint/typescript-eslint/commits/v8.1.0/packages/eslint-plugin)\n\nUpdates `@typescript-eslint/parser` from 8.0.1 to 8.1.0\n- [Release notes](https://github.com/typescript-eslint/typescript-eslint/releases)\n- [Changelog](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/parser/CHANGELOG.md)\n- [Commits](https://github.com/typescript-eslint/typescript-eslint/commits/v8.1.0/packages/parser)\n\n---\nupdated-dependencies:\n- dependency-name: \"@typescript-eslint/eslint-plugin\"\n  dependency-type: direct:development\n  update-type: version-update:semver-minor\n  dependency-group: typescript-eslint\n- dependency-name: \"@typescript-eslint/parser\"\n  dependency-type: direct:development\n  update-type: version-update:semver-minor\n  dependency-group: typescript-eslint\n...\n\nSigned-off-by: dependabot[bot] <support@github.com>\nCo-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>",
           "timestamp": "2024-08-16T04:27:37Z",
           "tree_id": "a89f8b810d1277a20a74a085a5dcb6062366f67d",
@@ -226,7 +226,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "2d1ade78ae2bb8c873809f169b7daea9315715b5",
+          "sha": "2d1ade78ae2bb8c873809f169b7daea9315715b5",
           "message": "Bump eslint from 9.8.0 to 9.9.0 in /src/TodoApp (#43)\n\nBumps [eslint](https://github.com/eslint/eslint) from 9.8.0 to 9.9.0.\n- [Release notes](https://github.com/eslint/eslint/releases)\n- [Changelog](https://github.com/eslint/eslint/blob/main/CHANGELOG.md)\n- [Commits](https://github.com/eslint/eslint/compare/v9.8.0...v9.9.0)\n\n---\nupdated-dependencies:\n- dependency-name: eslint\n  dependency-type: direct:development\n  update-type: version-update:semver-minor\n...\n\nSigned-off-by: dependabot[bot] <support@github.com>\nCo-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>",
           "timestamp": "2024-08-16T04:34:00Z",
           "tree_id": "aef32bb88dc5634184c15969737e4b346bc9d1ff",
@@ -268,7 +268,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "eee30b569f6cc768518be095c49335e25d11bcee",
+          "sha": "eee30b569f6cc768518be095c49335e25d11bcee",
           "message": "Bump elliptic from 6.5.6 to 6.5.7 in /src/TodoApp (#45)",
           "timestamp": "2024-08-16T07:00:11+01:00",
           "tree_id": "9bec64024a94bf9331aa2b41803a4262e0b7dde0",
@@ -310,7 +310,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "459b9cbc7079dd60ccabde497731b4cea439930e",
+          "sha": "459b9cbc7079dd60ccabde497731b4cea439930e",
           "message": "Bump @stylistic/eslint-plugin from 2.6.2 to 2.6.4 in /src/TodoApp (#44)",
           "timestamp": "2024-08-16T07:23:21+01:00",
           "tree_id": "c8bee0f6f8786e780eceaa669950c690a76ed782",

--- a/aspnetcore-openapi/index.html
+++ b/aspnetcore-openapi/index.html
@@ -130,7 +130,7 @@
     <footer>
       <p>
         &copy; Martin Costello 2024 |
-        Powered by <a rel="noopener" href="https://github.com/benchmark-action/github-action-benchmark">github-action-benchmark</a>
+        Powered by <a rel="noopener" href="https://github.com/martincostello/benchmarkdotnet-results-publisher">benchmarkdotnet-results-publisher</a>
         <button class="btn btn-primary btn-sm d-none d-md-block float-end" id="download-json" type="button">
           Download as JSON
           <span class="fa-solid fa-file-arrow-down" aria-hidden="true"></span>

--- a/charts.js
+++ b/charts.js
@@ -22,16 +22,15 @@
     const segments = window.location.pathname.split('/');
     const path = segments[segments.length - 2];
     const branch = new URLSearchParams(window.location.search).get('branch') || 'main';
-    const dataUrl = `https://raw.githubusercontent.com/martincostello/benchmarks/${branch}/${path}/data.js`;
+    const dataUrl = `https://raw.githubusercontent.com/martincostello/benchmarks/${branch}/${path}/data.json`;
 
-    // Fetch the data, trim the prefix and parse it as JSON
+    // Fetch the data and parse it as JSON
     const response = await fetch(dataUrl, { cache: 'no-cache' });
-    const dataText = await response.text();
-    const data = JSON.parse(dataText.slice('window.BENCHMARK_DATA = '.length));
+    const data = await response.json();
 
     // Render header
     document.getElementById('branch-name').textContent = branch;
-    document.getElementById('last-update').textContent = new Date(data.lastUpdate).toLocaleString();
+    document.getElementById('last-update').textContent = new Date(data.lastUpdated).toLocaleString();
     const repoLink = document.getElementById('repository-link');
     repoLink.href = data.repoUrl;
     repoLink.textContent = data.repoUrl;
@@ -67,20 +66,26 @@
 
       dataset.sort((a, b) => a.date - b.date);
 
-      const color = '#178600';
+      const memoryAxis = 'y2';
+      const memoryColor = '#e34c26';
+      const timeAxis = 'y';
+      const timeColor = '#178600';
+
       const data = {
-        labels: dataset.map(d => d.commit.id.slice(0, 7)),
+        labels: dataset.map(d => d.commit.sha.slice(0, 7)),
         datasets: [
           {
-            label: name,
+            label: `${name} (time)`,
             data: dataset.map(d => d.bench.value),
-            borderColor: color,
-            backgroundColor: `${color}60`, // Add alpha for #rrggbbaa
+            borderColor: timeColor,
+            backgroundColor: `${timeColor}60`,
             fill: true,
             tension: 0.4,
-          }
+            yAxisID: timeAxis,
+          },
         ],
       };
+
       const options = {
         scales: {
           x: {
@@ -113,11 +118,18 @@
               },
               label: context => {
                 const item = dataset[context.dataIndex];
-                let label = item.bench.value.toString();
-                const { range, unit } = item.bench;
-                label += unit;
-                if (range) {
-                  label += ` (${range})`;
+                const memory = context.datasetIndex === 1;
+                let label;
+                if (memory) {
+                  label = item.bench.bytesAllocated.toString();
+                  label += item.bench.memoryUnit;
+                } else {
+                  label = item.bench.value.toString();
+                  const { range, unit } = item.bench;
+                  label += unit;
+                  if (range) {
+                    label += ` (${range})`;
+                  }
                 }
                 return label;
               },
@@ -129,6 +141,28 @@
           },
         },
       };
+
+      const hasMemory = dataset.some(d => d.bench.bytesAllocated);
+      if (hasMemory) {
+        data.datasets.push({
+          label: `${name} (memory)`,
+          data: dataset.map(d => d.bench.bytesAllocated),
+          borderColor: memoryColor,
+          backgroundColor: `${memoryColor}60`,
+          fill: false,
+          pointStyle: 'triangle',
+          tension: 0.4,
+          yAxisID: memoryAxis,
+        });
+        options.scales[memoryAxis] = {
+          beginAtZero: true,
+          position: 'right',
+          title: {
+            display: hasMemory,
+            text: dataset.length > 0 ? dataset[0].bench.memoryUnit : '',
+          },
+        };
+      }
 
       new Chart(canvas, {
         type: 'line',
@@ -170,8 +204,8 @@
           }
 
           const factor = 1e-3;
-          const units = ['µs', 'ms', 's'];
-          for (let i = 0; i < units.length; i++) {
+          const timeUnits = ['µs', 'ms', 's'];
+          for (let i = 0; i < timeUnits.length; i++) {
             if (minValue < 1000) {
               break;
             }
@@ -179,9 +213,33 @@
             for (let j = 0; j < items.length; j++) {
               const item = items[j];
               item.bench.value *= factor;
-              item.bench.unit = units[i];
+              item.bench.unit = timeUnits[i];
               item.bench.range = `± ${parseFloat(item.bench.range.substring(2), 10) * factor}`;
             };
+          }
+
+          const hasMemory = items.some(item => item.bench.bytesAllocated);
+          if (hasMemory) {
+            minValue = items.length === 1 ? items[0].bench.bytesAllocated : Number.POSITIVE_INFINITY;
+
+            if (items.length > 1) {
+              for (const item of items) {
+                minValue = Math.min(minValue, item.bench.bytesAllocated);
+              };
+            }
+
+            const memoryUnits = ['KB', 'MB'];
+            for (let i = 0; i < memoryUnits.length; i++) {
+              if (minValue < 1000) {
+                break;
+              }
+              minValue *= factor;
+              for (let j = 0; j < items.length; j++) {
+                const item = items[j];
+                item.bench.bytesAllocated *= factor;
+                item.bench.memoryUnit = memoryUnits[i];
+              };
+            }
           }
         }
       });

--- a/charts.js
+++ b/charts.js
@@ -142,11 +142,11 @@
         },
       };
 
-      const hasMemory = dataset.some(d => d.bench.bytesAllocated);
+      const hasMemory = dataset.some(d => d.bench.bytesAllocated !== undefined);
       if (hasMemory) {
         data.datasets.push({
           label: `${name} (memory)`,
-          data: dataset.map(d => d.bench.bytesAllocated),
+          data: dataset.filter(d => d.bench.bytesAllocated != undefined).map(d => d.bench.bytesAllocated),
           borderColor: memoryColor,
           backgroundColor: `${memoryColor}60`,
           fill: false,
@@ -218,13 +218,15 @@
             };
           }
 
-          const hasMemory = items.some(item => item.bench.bytesAllocated);
+          const hasMemory = items.some(item => item.bench.bytesAllocated !== undefined);
           if (hasMemory) {
             minValue = items.length === 1 ? items[0].bench.bytesAllocated : Number.POSITIVE_INFINITY;
 
             if (items.length > 1) {
               for (const item of items) {
-                minValue = Math.min(minValue, item.bench.bytesAllocated);
+                if (item.bench.bytesAllocated !== undefined) {
+                  minValue = Math.min(minValue, item.bench.bytesAllocated);
+                }
               };
             }
 
@@ -236,8 +238,10 @@
               minValue *= factor;
               for (let j = 0; j < items.length; j++) {
                 const item = items[j];
-                item.bench.bytesAllocated *= factor;
-                item.bench.memoryUnit = memoryUnits[i];
+                if (item.bench.bytesAllocated !== undefined) {
+                  item.bench.bytesAllocated *= factor;
+                  item.bench.memoryUnit = memoryUnits[i];
+                }
               };
             }
           }

--- a/costellobot/data.json
+++ b/costellobot/data.json
@@ -1,5 +1,5 @@
-window.BENCHMARK_DATA = {
-  "lastUpdate": 1723798036925,
+{
+  "lastUpdated": 1723798036925,
   "repoUrl": "https://github.com/martincostello/costellobot",
   "entries": {
     "Costellobot": [
@@ -16,7 +16,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "03f70e83ef763e164f9e6976da070b43df8de456",
+          "sha": "03f70e83ef763e164f9e6976da070b43df8de456",
           "message": "Add continuous benchmarks\n\nAdd GitHub Actions workflow to run continuous benchmarks and publish to a tracking website.",
           "timestamp": "2024-08-13T09:53:25+01:00",
           "tree_id": "ae883c9eb3b092ed2fc0a1c1e98f93cc84e729ff",
@@ -58,7 +58,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "36d72c5ec00b996cb2a245a33c84693cb5b52e7e",
+          "sha": "36d72c5ec00b996cb2a245a33c84693cb5b52e7e",
           "message": "Update .NET SDK to 8.0.400 (#1619)\n\n* Update .NET SDK\n\nUpdate .NET SDK to version 8.0.400.\n\n---\nupdated-dependencies:\n- dependency-name: Microsoft.NET.Sdk\n  dependency-type: direct:production\n  update-type: version-update:semver-patch\n...\n\nSigned-off-by: costellobot <102549341+costellobot@users.noreply.github.com>\n\n* Bump .NET NuGet packages\n\nBumps .NET dependencies to their latest versions for the .NET 8.0.400 SDK.\n\nBumps Microsoft.AspNetCore.AzureAppServices.HostingStartup from 8.0.7 to 8.0.8.\nBumps Microsoft.AspNetCore.Mvc.Testing from 8.0.7 to 8.0.8.\n\n---\nupdated-dependencies:\n- dependency-name: Microsoft.AspNetCore.AzureAppServices.HostingStartup\n  dependency-type: direct:production\n  update-type: version-update:semver-patch\n- dependency-name: Microsoft.AspNetCore.Mvc.Testing\n  dependency-type: direct:production\n  update-type: version-update:semver-patch\n...\n\nSigned-off-by: costellobot <102549341+costellobot@users.noreply.github.com>\n\n---------\n\nSigned-off-by: costellobot <102549341+costellobot@users.noreply.github.com>",
           "timestamp": "2024-08-13T17:01:54Z",
           "tree_id": "3f50bf81d45ee0710834b72a7949360f5f1bb064",
@@ -100,7 +100,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "3a6e727a4ce128b4b2b4698fae2f3b80a9a5a2d7",
+          "sha": "3a6e727a4ce128b4b2b4698fae2f3b80a9a5a2d7",
           "message": "Bump github/codeql-action from 3.26.0 to 3.26.1 (#1621)\n\nBumps [github/codeql-action](https://github.com/github/codeql-action) from 3.26.0 to 3.26.1.\n- [Release notes](https://github.com/github/codeql-action/releases)\n- [Changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md)\n- [Commits](https://github.com/github/codeql-action/compare/eb055d739abdc2e8de2e5f4ba1a8b246daa779aa...29d86d22a34ea372b1bbf3b2dced2e25ca6b3384)\n\n---\nupdated-dependencies:\n- dependency-name: github/codeql-action\n  dependency-type: direct:production\n  update-type: version-update:semver-patch\n...\n\nSigned-off-by: dependabot[bot] <support@github.com>\nCo-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>",
           "timestamp": "2024-08-14T07:16:39Z",
           "tree_id": "130534bdce2df8cff043a4cb2c6ee7477789e3d0",
@@ -142,7 +142,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "f00f395c582aeb9e3ee1d385638a085ef7717e40",
+          "sha": "f00f395c582aeb9e3ee1d385638a085ef7717e40",
           "message": "Remove Microsoft.AspNetCore.DataProtection (#1622)\n\nRemove explicit package version for Microsoft.AspNetCore.DataProtection and replace with System.Drawing.Common instead to resolve vulnerability.",
           "timestamp": "2024-08-14T07:34:47Z",
           "tree_id": "51436bb92c6b71e9200348df232183d15e9c575b",
@@ -184,7 +184,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "0d74bca0360e809fab625583a34f5bcd7e6096d5",
+          "sha": "0d74bca0360e809fab625583a34f5bcd7e6096d5",
           "message": "Bump NuGet.Versioning from 6.10.2 to 6.11.0 (#1624)\n\nBumps [NuGet.Versioning](https://github.com/NuGet/NuGet.Client) from 6.10.2 to 6.11.0.\n- [Release notes](https://github.com/NuGet/NuGet.Client/releases)\n- [Commits](https://github.com/NuGet/NuGet.Client/commits)\n\n---\nupdated-dependencies:\n- dependency-name: NuGet.Versioning\n  dependency-type: direct:production\n  update-type: version-update:semver-minor\n...\n\nSigned-off-by: dependabot[bot] <support@github.com>\nCo-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>",
           "timestamp": "2024-08-14T08:06:06Z",
           "tree_id": "906517ef0764d48460cfaed0febfdf36c120bb5b",
@@ -226,7 +226,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "0752bdfd3a7a1e8b3cdb77f4e3c414564a5a3e45",
+          "sha": "0752bdfd3a7a1e8b3cdb77f4e3c414564a5a3e45",
           "message": "Bump the microsoft-extensions group with 2 updates (#1623)\n\nBumps the microsoft-extensions group with 2 updates: [Microsoft.Extensions.Http.Resilience](https://github.com/dotnet/extensions) and [Microsoft.Extensions.TimeProvider.Testing](https://github.com/dotnet/extensions).\n\n\nUpdates `Microsoft.Extensions.Http.Resilience` from 8.7.0 to 8.8.0\n- [Release notes](https://github.com/dotnet/extensions/releases)\n- [Commits](https://github.com/dotnet/extensions/commits)\n\nUpdates `Microsoft.Extensions.TimeProvider.Testing` from 8.7.0 to 8.8.0\n- [Release notes](https://github.com/dotnet/extensions/releases)\n- [Commits](https://github.com/dotnet/extensions/commits)\n\n---\nupdated-dependencies:\n- dependency-name: Microsoft.Extensions.Http.Resilience\n  dependency-type: direct:production\n  update-type: version-update:semver-minor\n  dependency-group: microsoft-extensions\n- dependency-name: Microsoft.Extensions.TimeProvider.Testing\n  dependency-type: direct:production\n  update-type: version-update:semver-minor\n  dependency-group: microsoft-extensions\n...\n\nSigned-off-by: dependabot[bot] <support@github.com>\nCo-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>",
           "timestamp": "2024-08-14T08:07:22Z",
           "tree_id": "a8db73dd6221f2fb30cecd43bf75fb426dd3cf7b",
@@ -268,7 +268,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "aadf1b0d8eb582ee144a15b8c858823424bf162f",
+          "sha": "aadf1b0d8eb582ee144a15b8c858823424bf162f",
           "message": "Bump elliptic\n\nBump elliptic to 6.5.7 to resolve vulnerability alert.",
           "timestamp": "2024-08-14T13:16:36+01:00",
           "tree_id": "f00493df073f576c06fe86ec265689b6f172cde3",
@@ -310,7 +310,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "bf5321af872a431b3d3ed914a66b88b7a646ee60",
+          "sha": "bf5321af872a431b3d3ed914a66b88b7a646ee60",
           "message": "Bump github/codeql-action from 3.26.1 to 3.26.2 (#1629)\n\nBumps [github/codeql-action](https://github.com/github/codeql-action) from 3.26.1 to 3.26.2.\n- [Release notes](https://github.com/github/codeql-action/releases)\n- [Changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md)\n- [Commits](https://github.com/github/codeql-action/compare/29d86d22a34ea372b1bbf3b2dced2e25ca6b3384...429e1977040da7a23b6822b13c129cd1ba93dbb2)\n\n---\nupdated-dependencies:\n- dependency-name: github/codeql-action\n  dependency-type: direct:production\n  update-type: version-update:semver-patch\n...\n\nSigned-off-by: dependabot[bot] <support@github.com>\nCo-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>",
           "timestamp": "2024-08-15T07:46:31Z",
           "tree_id": "28c630f8197d3f43cc17277b6e94e4971ae4a1e9",
@@ -352,7 +352,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "adb2e21e419da3a09571681b514df15b8862920e",
+          "sha": "adb2e21e419da3a09571681b514df15b8862920e",
           "message": "Update .NET SDK (#1631)\n\nUpdate .NET SDK to version 8.0.401.\n\n---\nupdated-dependencies:\n- dependency-name: Microsoft.NET.Sdk\n  dependency-type: direct:production\n  update-type: version-update:semver-patch\n...\n\nSigned-off-by: costellobot <102549341+costellobot@users.noreply.github.com>",
           "timestamp": "2024-08-15T17:40:41Z",
           "tree_id": "e04517e3c173a0f252ee27133471876946b181d3",
@@ -394,7 +394,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "96551696b0552812e38529d0508637a5110b7d58",
+          "sha": "96551696b0552812e38529d0508637a5110b7d58",
           "message": "Bump stylelint from 16.8.1 to 16.8.2 in /src/Costellobot (#1632)\n\nBumps [stylelint](https://github.com/stylelint/stylelint) from 16.8.1 to 16.8.2.\n- [Release notes](https://github.com/stylelint/stylelint/releases)\n- [Changelog](https://github.com/stylelint/stylelint/blob/main/CHANGELOG.md)\n- [Commits](https://github.com/stylelint/stylelint/compare/16.8.1...16.8.2)\n\n---\nupdated-dependencies:\n- dependency-name: stylelint\n  dependency-type: direct:production\n  update-type: version-update:semver-patch\n...\n\nSigned-off-by: dependabot[bot] <support@github.com>\nCo-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>",
           "timestamp": "2024-08-16T07:21:40Z",
           "tree_id": "c582ee3be869667235c48dfcc0540c724c59feef",
@@ -436,7 +436,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "f16d51e86d3af40c0b7a800b3440c3b35a59eaf5",
+          "sha": "f16d51e86d3af40c0b7a800b3440c3b35a59eaf5",
           "message": "Bump @stylistic/eslint-plugin from 2.6.2 to 2.6.4 in /src/Costellobot (#1633)\n\nBumps [@stylistic/eslint-plugin](https://github.com/eslint-stylistic/eslint-stylistic/tree/HEAD/packages/eslint-plugin) from 2.6.2 to 2.6.4.\n- [Release notes](https://github.com/eslint-stylistic/eslint-stylistic/releases)\n- [Changelog](https://github.com/eslint-stylistic/eslint-stylistic/blob/main/CHANGELOG.md)\n- [Commits](https://github.com/eslint-stylistic/eslint-stylistic/commits/v2.6.4/packages/eslint-plugin)\n\n---\nupdated-dependencies:\n- dependency-name: \"@stylistic/eslint-plugin\"\n  dependency-type: direct:production\n  update-type: version-update:semver-patch\n...\n\nSigned-off-by: dependabot[bot] <support@github.com>\nCo-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>",
           "timestamp": "2024-08-16T07:21:57Z",
           "tree_id": "72015fe7b9c76a578a400862476e1564e9179f9a",
@@ -478,7 +478,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "4e14e03e9d8c9f033500cbafe419714c4463ef0f",
+          "sha": "4e14e03e9d8c9f033500cbafe419714c4463ef0f",
           "message": "Bump Azure.Extensions.AspNetCore.Configuration.Secrets (#1634)\n\nBumps [Azure.Extensions.AspNetCore.Configuration.Secrets](https://github.com/Azure/azure-sdk-for-net) from 1.3.1 to 1.3.2.\n- [Release notes](https://github.com/Azure/azure-sdk-for-net/releases)\n- [Commits](https://github.com/Azure/azure-sdk-for-net/compare/Azure.Extensions.AspNetCore.Configuration.Secrets_1.3.1...Azure.Extensions.AspNetCore.Configuration.Secrets_1.3.2)\n\n---\nupdated-dependencies:\n- dependency-name: Azure.Extensions.AspNetCore.Configuration.Secrets\n  dependency-type: direct:production\n  update-type: version-update:semver-patch\n...\n\nSigned-off-by: dependabot[bot] <support@github.com>\nCo-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>",
           "timestamp": "2024-08-16T07:40:19Z",
           "tree_id": "c0c85ccdcacf2d08c83f29f7091199d16841995b",
@@ -520,7 +520,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "7adf1e5825599371549a9a3f6f49f0dfb48c251e",
+          "sha": "7adf1e5825599371549a9a3f6f49f0dfb48c251e",
           "message": "Bump Azure.Extensions.AspNetCore.DataProtection.Keys from 1.2.3 to 1.2.4 (#1635)\n\nBumps [Azure.Extensions.AspNetCore.DataProtection.Keys](https://github.com/Azure/azure-sdk-for-net) from 1.2.3 to 1.2.4.\r\n- [Release notes](https://github.com/Azure/azure-sdk-for-net/releases)\r\n- [Commits](https://github.com/Azure/azure-sdk-for-net/compare/Azure.Extensions.AspNetCore.DataProtection.Keys_1.2.3...Azure.Extensions.AspNetCore.DataProtection.Keys_1.2.4)\r\n\r\n---\r\nupdated-dependencies:\r\n- dependency-name: Azure.Extensions.AspNetCore.DataProtection.Keys\r\n  dependency-type: direct:production\r\n  update-type: version-update:semver-patch\r\n...\r\n\r\nSigned-off-by: dependabot[bot] <support@github.com>\r\nCo-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>",
           "timestamp": "2024-08-16T08:43:39+01:00",
           "tree_id": "85dd7c6366e964e99123c6ea8dcb00ca9b517a94",
@@ -562,7 +562,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "f94403b2ac7f5656e1895a12d2d5e01199e320d1",
+          "sha": "f94403b2ac7f5656e1895a12d2d5e01199e320d1",
           "message": "Update comment\n\nUpdate comment to reference new method for .NET 10.",
           "timestamp": "2024-08-16T09:44:05+01:00",
           "tree_id": "5100cac24b9b030edb6237cb1edf598dbb6bf75d",

--- a/costellobot/index.html
+++ b/costellobot/index.html
@@ -130,7 +130,7 @@
     <footer>
       <p>
         &copy; Martin Costello 2024 |
-        Powered by <a rel="noopener" href="https://github.com/benchmark-action/github-action-benchmark">github-action-benchmark</a>
+        Powered by <a rel="noopener" href="https://github.com/martincostello/benchmarkdotnet-results-publisher">benchmarkdotnet-results-publisher</a>
         <button class="btn btn-primary btn-sm d-none d-md-block float-end" id="download-json" type="button">
           Download as JSON
           <span class="fa-solid fa-file-arrow-down" aria-hidden="true"></span>

--- a/openapi-extensions/data.json
+++ b/openapi-extensions/data.json
@@ -1,5 +1,5 @@
-window.BENCHMARK_DATA = {
-  "lastUpdate": 1723695991041,
+{
+  "lastUpdated": 1723695991041,
   "repoUrl": "https://github.com/martincostello/openapi-extensions",
   "entries": {
     "OpenAPI Extensions": [
@@ -16,7 +16,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "79fa5eaa6ec3d92ab933fe55f07a5a0825db9989",
+          "sha": "79fa5eaa6ec3d92ab933fe55f07a5a0825db9989",
           "message": "Add continuous benchmarks\n\nAdd GitHub Actions workflow to run continuous benchmarks and publish to a tracking website.",
           "timestamp": "2024-08-10T17:40:10+01:00",
           "tree_id": "7248c3df126dc928237bd4e9ad228a2e83336aa6",
@@ -52,7 +52,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "3d2bd5330a83ead9b339a9f992c2b08e3aaa1b4b",
+          "sha": "3d2bd5330a83ead9b339a9f992c2b08e3aaa1b4b",
           "message": "Update .NET SDK\n\nUpdate to the latest build of .NET 9 preview 7.",
           "timestamp": "2024-08-10T17:48:13+01:00",
           "tree_id": "752738e44679ecd043466a431868af4e67ee0219",
@@ -88,7 +88,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "5a7cd2895f721a643df449c55de542dd52f21fa7",
+          "sha": "5a7cd2895f721a643df449c55de542dd52f21fa7",
           "message": "Bump actions/attest-build-provenance from 1.4.0 to 1.4.1 (#39)\n\nBumps [actions/attest-build-provenance](https://github.com/actions/attest-build-provenance) from 1.4.0 to 1.4.1.\n- [Release notes](https://github.com/actions/attest-build-provenance/releases)\n- [Changelog](https://github.com/actions/attest-build-provenance/blob/main/RELEASE.md)\n- [Commits](https://github.com/actions/attest-build-provenance/compare/210c1913531870065f03ce1f9440dd87bc0938cd...310b0a4a3b0b78ef57ecda988ee04b132db73ef8)\n\n---\nupdated-dependencies:\n- dependency-name: actions/attest-build-provenance\n  dependency-type: direct:production\n  update-type: version-update:semver-patch\n...\n\nSigned-off-by: dependabot[bot] <support@github.com>\nCo-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>",
           "timestamp": "2024-08-10T16:55:06Z",
           "tree_id": "a423b59d2cce5e6c959e87bb225b61711188a28b",
@@ -124,7 +124,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "0140004bd1935ebdb71a904b21acf78633901a6e",
+          "sha": "0140004bd1935ebdb71a904b21acf78633901a6e",
           "message": "Simplify benchmarks name\n\nRemove \"Benchmarks\" suffix.",
           "timestamp": "2024-08-11T12:28:44+01:00",
           "tree_id": "2d7ca1e4a260a44e2d8bdded41ff895617085751",
@@ -160,7 +160,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "f0010da64c4f5e6586775f074f7811b0c27962f0",
+          "sha": "f0010da64c4f5e6586775f074f7811b0c27962f0",
           "message": "Benchmark .NET vNext\n\n- Run benchmarks for pushes to the vNext branches.\n- Remove concurrency.",
           "timestamp": "2024-08-12T12:29:35+01:00",
           "tree_id": "d1d3805f503cf58df5335e79f9bf3c432a8f59d2",
@@ -196,7 +196,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "5f97deacf73c0a3aed026621aeb7616f9f4c681d",
+          "sha": "5f97deacf73c0a3aed026621aeb7616f9f4c681d",
           "message": "Link to the branch\n\nLink to the same branch's results.",
           "timestamp": "2024-08-12T12:39:58+01:00",
           "tree_id": "19085996ff80fa1dc9e1ea56384771b2014c912d",
@@ -232,7 +232,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "67c4e85a1369f6b9943e2efe9aa81a47e18a4c01",
+          "sha": "67c4e85a1369f6b9943e2efe9aa81a47e18a4c01",
           "message": "Bump Verify.Xunit\n\nBump Verify.Xunit to the latest version.",
           "timestamp": "2024-08-13T10:36:27+01:00",
           "tree_id": "1957a18933821ec01cfa2f1d48687fc23ebe163a",
@@ -268,7 +268,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "adf2803e9816910cd993b520b1e3f98408468c37",
+          "sha": "adf2803e9816910cd993b520b1e3f98408468c37",
           "message": "Use stable NuGet packages\n\nUse stable NuGet packages for .NET 9 preview 7.",
           "timestamp": "2024-08-13T14:52:58+01:00",
           "tree_id": "9debaae7b1306a86324b0a4ee0aae0e97dc7387b",
@@ -304,7 +304,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "f846e8a2ab5781e11f0c54363828c6747182c562",
+          "sha": "f846e8a2ab5781e11f0c54363828c6747182c562",
           "message": "Bump github/codeql-action from 3.26.0 to 3.26.1 (#49)\n\nBumps [github/codeql-action](https://github.com/github/codeql-action) from 3.26.0 to 3.26.1.\n- [Release notes](https://github.com/github/codeql-action/releases)\n- [Changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md)\n- [Commits](https://github.com/github/codeql-action/compare/eb055d739abdc2e8de2e5f4ba1a8b246daa779aa...29d86d22a34ea372b1bbf3b2dced2e25ca6b3384)\n\n---\nupdated-dependencies:\n- dependency-name: github/codeql-action\n  dependency-type: direct:production\n  update-type: version-update:semver-patch\n...\n\nSigned-off-by: dependabot[bot] <support@github.com>\nCo-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>",
           "timestamp": "2024-08-14T05:08:54Z",
           "tree_id": "424b6284a93ed5adad733e61376c6e80ab50c6fb",
@@ -340,7 +340,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "51722bc83944297bbe1cb9b97aa3974050210352",
+          "sha": "51722bc83944297bbe1cb9b97aa3974050210352",
           "message": "Bump anchore/sbom-action from 0.17.0 to 0.17.1 (#50)",
           "timestamp": "2024-08-14T06:34:36+01:00",
           "tree_id": "64993d1a9c3b601b5e19f561fc51369158cb80f8",
@@ -376,7 +376,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "6b5b0a4b85cc5135fcc00377ce4d4d2f0f55470c",
+          "sha": "6b5b0a4b85cc5135fcc00377ce4d4d2f0f55470c",
           "message": "Support .NET 9 rc.1\n\nReact to changes from dotnet/aspnetcore#57253 to support consuming CI builds in applications targeting .NET 9 rc.1 nightly builds.",
           "timestamp": "2024-08-14T09:20:07+01:00",
           "tree_id": "84c7bb682702f49b3f9dfd391d5f982bf10793af",
@@ -412,7 +412,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "b4a89c9f0fba87bc3af7b05875b3ac7eead1374c",
+          "sha": "b4a89c9f0fba87bc3af7b05875b3ac7eead1374c",
           "message": "Handle getter-only properties\n\nExtend the StyleCop prefix transformer to include get-only properties (\"Gets a value...\").",
           "timestamp": "2024-08-14T16:20:30+01:00",
           "tree_id": "532b8de324dedf4a75252cdc47d79e6d51fcd86c",
@@ -448,7 +448,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "636620af7a5b09c36ab5bcc6e2071e82bbd039a6",
+          "sha": "636620af7a5b09c36ab5bcc6e2071e82bbd039a6",
           "message": "Bump github/codeql-action from 3.26.1 to 3.26.2 (#56)\n\nBumps [github/codeql-action](https://github.com/github/codeql-action) from 3.26.1 to 3.26.2.\n- [Release notes](https://github.com/github/codeql-action/releases)\n- [Changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md)\n- [Commits](https://github.com/github/codeql-action/compare/29d86d22a34ea372b1bbf3b2dced2e25ca6b3384...429e1977040da7a23b6822b13c129cd1ba93dbb2)\n\n---\nupdated-dependencies:\n- dependency-name: github/codeql-action\n  dependency-type: direct:production\n  update-type: version-update:semver-patch\n...\n\nSigned-off-by: dependabot[bot] <support@github.com>\nCo-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>",
           "timestamp": "2024-08-15T04:24:42Z",
           "tree_id": "f4472f3602ee4340998f1421ac4d98e393aab85d",

--- a/openapi-extensions/index.html
+++ b/openapi-extensions/index.html
@@ -130,7 +130,7 @@
     <footer>
       <p>
         &copy; Martin Costello 2024 |
-        Powered by <a rel="noopener" href="https://github.com/benchmark-action/github-action-benchmark">github-action-benchmark</a>
+        Powered by <a rel="noopener" href="https://github.com/martincostello/benchmarkdotnet-results-publisher">benchmarkdotnet-results-publisher</a>
         <button class="btn btn-primary btn-sm d-none d-md-block float-end" id="download-json" type="button">
           Download as JSON
           <span class="fa-solid fa-file-arrow-down" aria-hidden="true"></span>

--- a/project-euler/data.json
+++ b/project-euler/data.json
@@ -1,5 +1,5 @@
-window.BENCHMARK_DATA = {
-  "lastUpdate": 1723744509678,
+{
+  "lastUpdated": 1723744509678,
   "repoUrl": "https://github.com/martincostello/project-euler",
   "entries": {
     "Project Euler": [
@@ -16,7 +16,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "4529f0f3e6133cca721896a2d4e2c7bfb12e01ce",
+          "sha": "4529f0f3e6133cca721896a2d4e2c7bfb12e01ce",
           "message": "Fix filter\n\nFix the default filter for Linux.",
           "timestamp": "2024-08-11T12:52:57+01:00",
           "tree_id": "7f5ce87bb98eddc445f924c48d4fd5dcd949b5e9",
@@ -364,7 +364,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "511eeac57cc659b0b11e52c2b8952c5041d241a1",
+          "sha": "511eeac57cc659b0b11e52c2b8952c5041d241a1",
           "message": "Benchmark .NET vNext\n\n- Run benchmarks for pushes to the vNext branches.\n- Remove concurrency.",
           "timestamp": "2024-08-12T12:31:45+01:00",
           "tree_id": "65d174e60bb9e2978eaf9792bf931346bdc8acbf",
@@ -712,7 +712,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "2dc8a5e17fb25dd623c5b2b1c54a428a23a7b105",
+          "sha": "2dc8a5e17fb25dd623c5b2b1c54a428a23a7b105",
           "message": "Link to the branch\n\nLink to the same branch's results.",
           "timestamp": "2024-08-12T12:42:34+01:00",
           "tree_id": "2b5a6d2c83ca9631b1a8dea4acd752bb237b71af",
@@ -1060,7 +1060,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "3e7c7bf801ce94c37b164ea662980658b05263f2",
+          "sha": "3e7c7bf801ce94c37b164ea662980658b05263f2",
           "message": "Update .NET SDK (#518)\n\nUpdate .NET SDK to version 8.0.400.\n\n---\nupdated-dependencies:\n- dependency-name: Microsoft.NET.Sdk\n  dependency-type: direct:production\n  update-type: version-update:semver-patch\n...\n\nSigned-off-by: costellobot <102549341+costellobot@users.noreply.github.com>",
           "timestamp": "2024-08-13T17:03:59Z",
           "tree_id": "14d2e9ab2268ec538fa57842ea437eae25ebb351",
@@ -1408,7 +1408,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "b60225fa23a3e2a0599acbb9f35ed868c19b65f7",
+          "sha": "b60225fa23a3e2a0599acbb9f35ed868c19b65f7",
           "message": "Fix SA1507 warning\n\nFix SA1507 for .NET Bumper targeting .NET 9.",
           "timestamp": "2024-08-15T07:27:42+01:00",
           "tree_id": "d1a6f49ed9a9470bd487aa61009304a82da0a797",
@@ -1756,7 +1756,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "61e097eb8bc6e62502182f16076f5ac28ca00500",
+          "sha": "61e097eb8bc6e62502182f16076f5ac28ca00500",
           "message": "Remove BenchmarkDotNet.TestAdapter\r\nRemove BenchmarkDotNet.TestAdapter as it might be the source of the slow .NET Bumper runs for .NET 9 for this repo.",
           "timestamp": "2024-08-15T15:58:06+01:00",
           "tree_id": "166cbecae083cc00741555a9da026461fa5c9c2e",
@@ -2104,7 +2104,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "b42721f7e71ad867bd458297bfc13bdfc4966e85",
+          "sha": "b42721f7e71ad867bd458297bfc13bdfc4966e85",
           "message": "Update .NET SDK (#526)\n\nUpdate .NET SDK to version 8.0.401.\n\n---\nupdated-dependencies:\n- dependency-name: Microsoft.NET.Sdk\n  dependency-type: direct:production\n  update-type: version-update:semver-patch\n...\n\nSigned-off-by: costellobot <102549341+costellobot@users.noreply.github.com>",
           "timestamp": "2024-08-15T17:45:24Z",
           "tree_id": "8682e065db723aff99c46fbdfb20a825ad737807",

--- a/project-euler/index.html
+++ b/project-euler/index.html
@@ -130,7 +130,7 @@
     <footer>
       <p>
         &copy; Martin Costello 2024 |
-        Powered by <a rel="noopener" href="https://github.com/benchmark-action/github-action-benchmark">github-action-benchmark</a>
+        Powered by <a rel="noopener" href="https://github.com/martincostello/benchmarkdotnet-results-publisher">benchmarkdotnet-results-publisher</a>
         <button class="btn btn-primary btn-sm d-none d-md-block float-end" id="download-json" type="button">
           Download as JSON
           <span class="fa-solid fa-file-arrow-down" aria-hidden="true"></span>

--- a/website/data.json
+++ b/website/data.json
@@ -1,5 +1,5 @@
-window.BENCHMARK_DATA = {
-  "lastUpdate": 1723789572742,
+{
+  "lastUpdated": 1723789572742,
   "repoUrl": "https://github.com/martincostello/website",
   "entries": {
     "Website": [
@@ -16,7 +16,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "c3b2faa9c3bcd635d801f3986caf64cbd2b67cd1",
+          "sha": "c3b2faa9c3bcd635d801f3986caf64cbd2b67cd1",
           "message": "Add continuous benchmarks\n\nAdd GitHub Actions workflow to run continuous benchmarks and publish to a tracking website.",
           "timestamp": "2024-08-11T19:51:17+01:00",
           "tree_id": "16b098f3a6ab7f82356f434bc038fd0cdc8c020f",
@@ -70,7 +70,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "d1895da44f19ca851a0921e787a051b48fe88ca5",
+          "sha": "d1895da44f19ca851a0921e787a051b48fe88ca5",
           "message": "Fix benchmarks name\n\nFix copy-pasta name.",
           "timestamp": "2024-08-11T20:03:33+01:00",
           "tree_id": "bc049a450638eac49c07003e3f98d1c78cfc231f",
@@ -124,7 +124,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "093ae038a39531f24a7030aeb41d0d4fc3da5c62",
+          "sha": "093ae038a39531f24a7030aeb41d0d4fc3da5c62",
           "message": "Bump eslint from 9.8.0 to 9.9.0 in /src/Website (#2154)\n\nBumps [eslint](https://github.com/eslint/eslint) from 9.8.0 to 9.9.0.\n- [Release notes](https://github.com/eslint/eslint/releases)\n- [Changelog](https://github.com/eslint/eslint/blob/main/CHANGELOG.md)\n- [Commits](https://github.com/eslint/eslint/compare/v9.8.0...v9.9.0)\n\n---\nupdated-dependencies:\n- dependency-name: eslint\n  dependency-type: direct:development\n  update-type: version-update:semver-minor\n...\n\nSigned-off-by: dependabot[bot] <support@github.com>\nCo-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>",
           "timestamp": "2024-08-11T19:15:13Z",
           "tree_id": "38594746f3e12d47042df5eec29ff76b5465b0b7",
@@ -178,7 +178,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "c0fad7edf51d2b6f5878d4db029357483f212276",
+          "sha": "c0fad7edf51d2b6f5878d4db029357483f212276",
           "message": "Remove redundant files\n\nRemove files that are now served from CDN.",
           "timestamp": "2024-08-12T08:35:56+01:00",
           "tree_id": "69ff3bc0f14e4c46ff2071f73656facca8d71b02",
@@ -232,7 +232,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "7ec25052885f6d2354c0ba9106117124a4456772",
+          "sha": "7ec25052885f6d2354c0ba9106117124a4456772",
           "message": "Benchmark .NET vNext (#2156)\n\n- Run benchmarks for pushes to the vNext branches.\r\n- Remove concurrency.",
           "timestamp": "2024-08-12T11:46:40Z",
           "tree_id": "3bc2f7bad15ffa151c32bacca181fab2222c86c0",
@@ -286,7 +286,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "592460bdb37bb4fd9e5a42043c83b3796e471a0c",
+          "sha": "592460bdb37bb4fd9e5a42043c83b3796e471a0c",
           "message": "Bump the typescript-eslint group in /src/Website with 2 updates (#2157)\n\nBumps the typescript-eslint group in /src/Website with 2 updates: [@typescript-eslint/eslint-plugin](https://github.com/typescript-eslint/typescript-eslint/tree/HEAD/packages/eslint-plugin) and [@typescript-eslint/parser](https://github.com/typescript-eslint/typescript-eslint/tree/HEAD/packages/parser).\n\n\nUpdates `@typescript-eslint/eslint-plugin` from 8.0.1 to 8.1.0\n- [Release notes](https://github.com/typescript-eslint/typescript-eslint/releases)\n- [Changelog](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/CHANGELOG.md)\n- [Commits](https://github.com/typescript-eslint/typescript-eslint/commits/v8.1.0/packages/eslint-plugin)\n\nUpdates `@typescript-eslint/parser` from 8.0.1 to 8.1.0\n- [Release notes](https://github.com/typescript-eslint/typescript-eslint/releases)\n- [Changelog](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/parser/CHANGELOG.md)\n- [Commits](https://github.com/typescript-eslint/typescript-eslint/commits/v8.1.0/packages/parser)\n\n---\nupdated-dependencies:\n- dependency-name: \"@typescript-eslint/eslint-plugin\"\n  dependency-type: direct:development\n  update-type: version-update:semver-minor\n  dependency-group: typescript-eslint\n- dependency-name: \"@typescript-eslint/parser\"\n  dependency-type: direct:development\n  update-type: version-update:semver-minor\n  dependency-group: typescript-eslint\n...\n\nSigned-off-by: dependabot[bot] <support@github.com>\nCo-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>",
           "timestamp": "2024-08-13T04:18:20Z",
           "tree_id": "2828492fafcbd955dd4c3133118ed4aaf5789f3f",
@@ -340,7 +340,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "924a7ab26248c77df35a63227db253da31e0aa0f",
+          "sha": "924a7ab26248c77df35a63227db253da31e0aa0f",
           "message": "Bump Microsoft.Playwright from 1.45.1 to 1.46.0 (#2158)\n\nBumps [Microsoft.Playwright](https://github.com/microsoft/playwright-dotnet) from 1.45.1 to 1.46.0.\n- [Release notes](https://github.com/microsoft/playwright-dotnet/releases)\n- [Commits](https://github.com/microsoft/playwright-dotnet/compare/v1.45.1...v1.46.0)\n\n---\nupdated-dependencies:\n- dependency-name: Microsoft.Playwright\n  dependency-type: direct:production\n  update-type: version-update:semver-minor\n...\n\nSigned-off-by: dependabot[bot] <support@github.com>\nCo-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>",
           "timestamp": "2024-08-13T04:39:08Z",
           "tree_id": "55a82d5e5c825e7cb388739607b603ef0132246a",
@@ -394,7 +394,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "8553cf7d430e66068bdb43a31e2028ab871ab994",
+          "sha": "8553cf7d430e66068bdb43a31e2028ab871ab994",
           "message": "Update .NET SDK to 8.0.400 (#2160)\n\n* Update .NET SDK\n\nUpdate .NET SDK to version 8.0.400.\n\n---\nupdated-dependencies:\n- dependency-name: Microsoft.NET.Sdk\n  dependency-type: direct:production\n  update-type: version-update:semver-patch\n...\n\nSigned-off-by: costellobot <102549341+costellobot@users.noreply.github.com>\n\n* Bump .NET NuGet packages\n\nBumps .NET dependencies to their latest versions for the .NET 8.0.400 SDK.\n\nBumps Microsoft.AspNetCore.AzureAppServices.HostingStartup from 8.0.7 to 8.0.8.\nBumps Microsoft.AspNetCore.Mvc.Testing from 8.0.7 to 8.0.8.\n\n---\nupdated-dependencies:\n- dependency-name: Microsoft.AspNetCore.AzureAppServices.HostingStartup\n  dependency-type: direct:production\n  update-type: version-update:semver-patch\n- dependency-name: Microsoft.AspNetCore.Mvc.Testing\n  dependency-type: direct:production\n  update-type: version-update:semver-patch\n...\n\nSigned-off-by: costellobot <102549341+costellobot@users.noreply.github.com>\n\n---------\n\nSigned-off-by: costellobot <102549341+costellobot@users.noreply.github.com>",
           "timestamp": "2024-08-13T17:28:29Z",
           "tree_id": "8d64eac4f8eb27bdcb85b610152806c7a79db893",
@@ -448,7 +448,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "fb0e0aba3b793e3a2690bde2baea975c27eb31e0",
+          "sha": "fb0e0aba3b793e3a2690bde2baea975c27eb31e0",
           "message": "Remove workaround\n\nRemove workaround for bug fixed in .NET 8.0.400 SDK.",
           "timestamp": "2024-08-13T18:39:14+01:00",
           "tree_id": "1a37642c7c81bcfcd8996c3579f07350e1ffc09f",
@@ -502,7 +502,7 @@ window.BENCHMARK_DATA = {
             "username": "martincostello"
           },
           "distinct": true,
-          "id": "ebcba41f0e05656af0a3548e617dccc2d1105fa8",
+          "sha": "ebcba41f0e05656af0a3548e617dccc2d1105fa8",
           "message": "Bump elliptic\n\nBump elliptic to 6.5.7 to resolve vulnerability alert.",
           "timestamp": "2024-08-14T12:49:09+01:00",
           "tree_id": "71c6e75f56253de97c29d253d67a5e8076eae860",
@@ -556,7 +556,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "54e13509c856ba2236bd7d4c5baf23b746aef31c",
+          "sha": "54e13509c856ba2236bd7d4c5baf23b746aef31c",
           "message": "Update .NET SDK (#2167)\n\nUpdate .NET SDK to version 8.0.401.\n\n---\nupdated-dependencies:\n- dependency-name: Microsoft.NET.Sdk\n  dependency-type: direct:production\n  update-type: version-update:semver-patch\n...\n\nSigned-off-by: costellobot <102549341+costellobot@users.noreply.github.com>",
           "timestamp": "2024-08-15T17:52:23Z",
           "tree_id": "5959d3a95e7f42d0013b59a0b937d417cf35fdfd",
@@ -610,7 +610,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "3fc73fc640ee875c9bffaad10718af536d0e38b6",
+          "sha": "3fc73fc640ee875c9bffaad10718af536d0e38b6",
           "message": "Bump stylelint from 16.8.1 to 16.8.2 in /src/Website (#2169)",
           "timestamp": "2024-08-16T07:22:24+01:00",
           "tree_id": "22bcf2addcc21d743a0df760b4dbca5767e0a5ba",
@@ -664,7 +664,7 @@ window.BENCHMARK_DATA = {
             "username": "web-flow"
           },
           "distinct": true,
-          "id": "eb7f746e5677144a281a358554e00d413a0e0906",
+          "sha": "eb7f746e5677144a281a358554e00d413a0e0906",
           "message": "Bump @stylistic/eslint-plugin from 2.6.2 to 2.6.4 in /src/Website (#2168)",
           "timestamp": "2024-08-16T07:22:38+01:00",
           "tree_id": "dd45165696aef72b6c66e92f779d953aefb83569",

--- a/website/index.html
+++ b/website/index.html
@@ -130,7 +130,7 @@
     <footer>
       <p>
         &copy; Martin Costello 2024 |
-        Powered by <a rel="noopener" href="https://github.com/benchmark-action/github-action-benchmark">github-action-benchmark</a>
+        Powered by <a rel="noopener" href="https://github.com/martincostello/benchmarkdotnet-results-publisher">benchmarkdotnet-results-publisher</a>
         <button class="btn btn-primary btn-sm d-none d-md-block float-end" id="download-json" type="button">
           Download as JSON
           <span class="fa-solid fa-file-arrow-down" aria-hidden="true"></span>


### PR DESCRIPTION
- Use JSON data from `martincostello/benchmarkdotnet-results-publisher` instead of `benchmark-action/github-action-benchmark`.
- Add support for plotting memory usage.
- Migrate data to new format.
